### PR TITLE
商品一覧表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create]
   def index
-    # @items = Item.order("created_at DESC")
+    @items = Item.order("created_at DESC")
   end
 
   def new

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -127,13 +127,13 @@
       新規投稿商品
     </div>
     <ul class='item-lists'>
-    <%# if @items.any? %>
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-      <%# @items.each do |item| %>
+    <% if @items.any? %>
+    
+      <% @items.each do |item| %>
       <li class='list'>
-        <%#= link_to "#" do %>
+        <%= link_to "#" do %>
         <div class='item-img-content'>
-          <%#= image_tag item.image, class: "item-img" %>
+          <%= image_tag item.image, class: "item-img" %>
           
           <%# 商品が売れていればsold outを表示しましょう %>
           <div class='sold-out'>
@@ -144,24 +144,21 @@
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%#= item.item_name %>
+            <%= item.item_name %>
           </h3>
           <div class='item-price'>
-            <span>販売価格 <%#= item.price %>円<br>配送料負担 <%#= item.shipping_fee.name %></span>
+            <span><%= item.price %>円<br><%= item.shipping_fee.name %></span>
             <div class='star-btn'>
-              <%#= image_tag "star.png", class:"star-icon" %>
+              <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
             </div>
           </div>
         </div>
-        <%# end %>
+        <% end %>
       </li>
-      <%# end %>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
-      <%# else %>
+      <% end %>
+    
+      <% else %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
@@ -179,9 +176,8 @@
         </div>
       </li>
       <% end %>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-    <%# end %>
+    
+    <% end %>
     </ul>
   </div>
   <%# /商品一覧 %>


### PR DESCRIPTION
#What
トップページ下部へ商品一覧表示の追加

#Why
商品一覧表示機能を実装する為

商品のデータがない場合は、ダミー商品が表示されている動画
https://gyazo.com/8e361d25a44c89f065c4346d84cbf0a2


商品のデータがある場合は、商品が一覧で表示されている動画
https://gyazo.com/ae3b537d3afeefe9fa602276da45ffbf